### PR TITLE
Fix verification for provision token

### DIFF
--- a/lib/cli-create-token.ts
+++ b/lib/cli-create-token.ts
@@ -56,7 +56,7 @@ export default function CliCreateToken() {
                     token = powerbi.PowerBIToken.createDevToken(settings.collection, settings.workspace);
                     break;
                 case 'provision':
-                    if (!(settings.collection && settings.workspace)) {
+                    if (!(settings.collection)) {
                         return cli.error('collection param is required');
                     }
                     token = powerbi.PowerBIToken.createProvisionToken(settings.collection);


### PR DESCRIPTION
The provision token is checking for a workspace, which it does not need.