### PR TITLE
Update import example command to include dataset name

### DIFF
--- a/lib/cli-import.ts
+++ b/lib/cli-import.ts
@@ -24,7 +24,7 @@ export default function CliImport() {
     program.on('--help', function () {
         console.log('  Examples:');
         console.log('');
-        console.log('    $ powerbi import -c <collection> -k <accessKey> -w <workspace> -f <file>');
+        console.log('    $ powerbi import -c <collection> -k <accessKey> -w <workspace> -f <file> -n <displayName>');
     });
 
     program.parse(process.argv);


### PR DESCRIPTION
The import help shows the example command usage without specifying dataset display name making it appear as optional but it is not optional and the import request will fail without it.

This adds the `-n <displayName>` option to the command to make it more clear.