### PR TITLE
Fix TypeError: callback is not a function

### DIFF
--- a/lib/cli-update-connection.ts
+++ b/lib/cli-update-connection.ts
@@ -119,7 +119,7 @@ export default function CliUpdateConnection() {
             };
 
             client.gateways.patchDatasource(settings.collection, settings.workspace, datasource.gatewayId, datasource.id, delta, (err, patchResult) => {
-                if (err) {
+                if (callback && err) {
                     return callback(err);
                 }
 


### PR DESCRIPTION
This PR fixes the callback is not a function issue that appears during the execution of the **powerbi update-connection** command in powershell.