### PR TITLE
Fix the the wrong credential issue on import

### DIFF
--- a/lib/cli-update-connection.ts
+++ b/lib/cli-update-connection.ts
@@ -42,19 +42,19 @@ export default function CliUpdateConnection() {
                 cli.success('Found dataset!');
                 cli.print('Id: %s', result.id);
                 cli.print('Name: %s', result.name);
-
-                if (settings.connectionString) {
-                    updateConnectionString(client, settings, function (updateConnectionStringError) {
-                        if (updateConnectionStringError) {
-                            return cli.error(updateConnectionStringError);
-                        }
-                    });
-                }
-
+                
                 if (settings.username && settings.password) {
                     updateCredentials(client, settings, function (updateCredentialsError) {
                         if (updateCredentialsError) {
                             return cli.error(updateCredentialsError);
+                        }
+                    });
+                }
+                
+                if (settings.connectionString) {
+                    updateConnectionString(client, settings, function (updateConnectionStringError) {
+                        if (updateConnectionStringError) {
+                            return cli.error(updateConnectionStringError);
                         }
                     });
                 }


### PR DESCRIPTION
Happens when you try to import the template of the report with a fake credentials and execute "powerbi update-connection" right after that. It updates the connection string and tries to connect before updating the credentials.