### PR TITLE
improve package json

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,18 +9,26 @@ git clone https://github.com/Microsoft/PowerBI-Cli.git powerbi-cli
 
 Navigate to the cloned directory
 
-Install typescript and local dependencies - you need to run it only once.
+Install dependencies and dev-dependencies.
 ```
-npm run precontrib
+npm i
 ```
 
 ## Build:
 
 ```
-npm run contrib
+npm run prepublish
 ```
 
-## Running the CLI
+## Install CLI from local repository:
+
+In root git repository directory:
+
+```
+npm i -g
+```
+
+## Running the CLI without installation
 
 Navigate to `/bin` directory and run cli file using node.
 
@@ -28,7 +36,7 @@ Navigate to `/bin` directory and run cli file using node.
 cd bin & node cli
 ```
 
-## Running specific command:
+### Running specific command:
 
 Navigate to `/bin` directory and run specific cli file using node.
 Example:

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "main": "./index.js",
   "typings": "./index.d.ts",
   "scripts": {
-    "precontrib": "npm install -g typings typescript && npm install",
-    "contrib": "typings install && tsc"
+    "prepublish": "typings install && tsc"
   },
   "author": "PowerBI <nugetpowerbi@microsoft.com> (https://dev.powerbi.com)",
   "license": "MIT",
@@ -20,7 +19,10 @@
     "ms-rest": "^1.12.0",
     "powerbi-api": "^1.2"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "typescript": "^2.2.2",
+    "typings": "^2.1.0"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Microsoft/PowerBI-Cli.git"


### PR DESCRIPTION
- add typings, typescript as dev deps
- use `prepublish` script (standard hook) instead of `contrib + precontrib`

`prepublish` is a standard hook that gets executed automatically after `npm i`.
It is also automatically executed during npm publish.